### PR TITLE
Update to MV3 & Allow first-time users to setup protocol settings

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Portions Copyright (C) Philipp Kewisch, 2017 */
 
-chrome.browserAction.onClicked.addListener(async (tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
   let { quickentry, reveal, when } = await browser.storage.local.get({ quickentry: true, reveal: true, when: "inbox" });
 
   let url = `things:add?title=${encodeURIComponent(tab.title)}&notes=${encodeURIComponent(tab.url)}&show-quick-entry=${quickentry}&reveal=${reveal}`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Send To Things",
   "description": "Send the current tab to Things",
-  "version": "1.2.1",
-  "applications": {
+  "version": "1.2.2",
+  "browser_specific_settings": {
     "gecko": {
       "id": "send-to-things@mozilla.kewis.ch"
     }
@@ -19,14 +19,12 @@
   ],
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
-  "browser_action": {
+  "action": {
     "default_icon": "images/things.png",
-    "default_title": "Send To Things",
-    "browser_style": false
+    "default_title": "Send To Things"
   },
 
   "commands": {
@@ -39,8 +37,6 @@
   },
 
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "scripts": ["background.js"]
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Send To Things",
   "description": "Send the current tab to Things",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "send-to-things@mozilla.kewis.ch"

--- a/options/options.html
+++ b/options/options.html
@@ -10,13 +10,13 @@
     </style>
   </head>
   <body>
-    <div class="browser-style">
+    <div>
       <input type="checkbox" id="quickentry"/>
       <label for="quickentry">Show Quick Entry dialog instead of saving task directly</label>
     </div>
     <div>
       <label for="when">List to add tasks to:</label>
-      <select class="browser-style" id="when">
+      <select id="when">
         <option value="inbox">Inbox</option>
         <option value="today">Today</option>
         <option value="tomorrow">Tomorrow</option>
@@ -24,7 +24,7 @@
         <option value="someday">Someday</option>
       </select>
     </div>
-    <div class="browser-style" id="reveal-container">
+    <div id="reveal-container">
       <input type="checkbox" id="reveal"/>
       <label for="reveal">Navigate to newly created tasks</label>
     </div>

--- a/options/options.html
+++ b/options/options.html
@@ -28,6 +28,9 @@
       <input type="checkbox" id="reveal"/>
       <label for="reveal">Navigate to newly created tasks</label>
     </div>
+    <div>
+      <button id="setup">Redo Setup</button>
+    </div>
     <script src="options.js"></script>
   </body>
 </html>

--- a/options/options.js
+++ b/options/options.js
@@ -62,6 +62,18 @@ async function load() {
   updateRevealState();
 }
 
+function promptSetup() {
+  let title = "welcome to Send To Things Firefox extension"
+  let url = `things:add?title=${encodeURIComponent(title)}&show-quick-entry=true&reveal=true`
+
+  browser.tabs.create({
+    active: true,
+    url: url
+  });
+
+  browser.storage.local.set({firstLoad: false})
+}
+
 function listen() {
   let showNode = document.getElementById("quickentry");
   showNode.addEventListener("click", save);
@@ -72,6 +84,9 @@ function listen() {
 
   let whenNode = document.getElementById("when");
   whenNode.addEventListener("change", save);
+
+  let setupNode = document.getElementById("setup");
+  setupNode.addEventListener("click", promptSetup)
 }
 
 (async function() {

--- a/options/options.js
+++ b/options/options.js
@@ -63,7 +63,7 @@ async function load() {
 }
 
 function promptSetup() {
-  let title = "welcome to Send To Things Firefox extension"
+  let title = "Enjoy the Send To Things Firefox extension"
   let url = `things:add?title=${encodeURIComponent(title)}&show-quick-entry=true&reveal=true`
 
   browser.tabs.create({


### PR DESCRIPTION
Previously, if a user had loaded the application for the first time, they would see a tab flash open and immediately shut, with nothing added to their Thing3 app.

I suspect this may be due to a recent change in behaviour in [Firefox's TabStatus field](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus) where a status will move to "complete" while the page is still waiting for a user to select the application to associate with a new protocol (ie. `things:`) and allow the extension to open the application automatically.

This PR:
- updates the Extension Manifest to Version 3 from Version 2 (and makes some minor changes as were required)
- adds logic to keep prevent auto-closing the tab that prompts the user for their preferences on first use of the extension
- exposes a "redo setup" button in extension options to re-prompt the user to go through these setup steps